### PR TITLE
Enhance marketplace filtering and add trending valuations

### DIFF
--- a/backend/src/router.js
+++ b/backend/src/router.js
@@ -1,7 +1,7 @@
 const url = require('url');
 const { getUserFromToken } = require('./auth');
 const { identifyCard, searchCards } = require('./services/cards');
-const { getValuation } = require('./services/valuation');
+const { getValuation, getTrendingValuations } = require('./services/valuation');
 const { listActiveListings, createListing, updateListingStatus } = require('./services/marketplace');
 const { listCategories, listPosts, createPost } = require('./services/forum');
 const { listThreads, createThread, appendMessage } = require('./services/messaging');
@@ -197,8 +197,18 @@ router.register(
   'GET',
   '/api/marketplace/listings',
   async ({ query }) => {
-    const { game, status, sellerId } = query;
-    const data = listActiveListings({ game, status, sellerId });
+    const { game, status, sellerId, minPrice, maxPrice, sortBy, sortOrder } = query;
+    const parsedMinPrice = minPrice !== undefined ? Number.parseFloat(minPrice) : undefined;
+    const parsedMaxPrice = maxPrice !== undefined ? Number.parseFloat(maxPrice) : undefined;
+    const data = listActiveListings({
+      game,
+      status,
+      sellerId,
+      minPrice: Number.isFinite(parsedMinPrice) ? parsedMinPrice : undefined,
+      maxPrice: Number.isFinite(parsedMaxPrice) ? parsedMaxPrice : undefined,
+      sortBy,
+      sortOrder,
+    });
     return { status: 200, data: { listings: data } };
   },
   { auth: false },
@@ -307,6 +317,16 @@ router.register(
   },
   { auth: true },
 );
+
+router.register('GET', '/api/cards/trending', async ({ query }) => {
+  const limit = query.limit !== undefined ? Number.parseInt(query.limit, 10) : undefined;
+  const window = query.window !== undefined ? Number.parseInt(query.window, 10) : undefined;
+  const results = getTrendingValuations({
+    limit: Number.isFinite(limit) ? limit : undefined,
+    window: Number.isFinite(window) ? window : undefined,
+  });
+  return { status: 200, data: { results } };
+});
 
 module.exports = {
   router,

--- a/backend/src/services/cards.js
+++ b/backend/src/services/cards.js
@@ -6,19 +6,42 @@ function searchCards(query) {
   if (!normalized) {
     return cards.slice(0, 10);
   }
-  return cards.filter((card) => {
-    const haystack = [
-      card.name,
-      card.game,
-      card.edition,
-      card.variant,
-      card.setNumber,
-    ]
-      .filter(Boolean)
-      .join(' ')
-      .toLowerCase();
-    return haystack.includes(normalized);
-  });
+
+  const tokens = normalized
+    .split(/\s+/g)
+    .map((token) => token.trim())
+    .filter(Boolean);
+
+  if (tokens.length === 0) {
+    return cards.slice(0, 10);
+  }
+
+  return cards
+    .map((card) => {
+      const haystack = [
+        card.name,
+        card.game,
+        card.edition,
+        card.variant,
+        card.setNumber,
+        card.year,
+      ]
+        .filter((part) => part !== undefined && part !== null)
+        .join(' ')
+        .toLowerCase();
+
+      const matches = tokens.reduce((score, token) => {
+        if (haystack.includes(token)) {
+          return score + token.length;
+        }
+        return score;
+      }, 0);
+
+      return { card, score: matches };
+    })
+    .filter((entry) => entry.score > 0)
+    .sort((a, b) => b.score - a.score)
+    .map((entry) => entry.card);
 }
 
 function identifyCard({ imageText, hints = [] }) {

--- a/backend/src/services/marketplace.js
+++ b/backend/src/services/marketplace.js
@@ -2,22 +2,50 @@ const crypto = require('crypto');
 const { listings, cards } = require('../store');
 
 function listActiveListings(filters = {}) {
-  const { game, status = 'active', sellerId } = filters;
-  return listings.filter((listing) => {
-    if (status && listing.status !== status) {
-      return false;
-    }
-    if (game) {
-      const card = cards.find((item) => item.id === listing.cardId);
-      if (!card || card.game.toLowerCase() !== game.toLowerCase()) {
+  const {
+    game,
+    status = 'active',
+    sellerId,
+    minPrice,
+    maxPrice,
+    sortBy = 'updatedAt',
+    sortOrder = 'desc',
+  } = filters;
+
+  const normalizedSortBy = ['price', 'updatedAt'].includes(sortBy) ? sortBy : 'updatedAt';
+  const normalizedSortOrder = sortOrder === 'asc' ? 'asc' : 'desc';
+
+  return listings
+    .filter((listing) => {
+      if (status && listing.status !== status) {
         return false;
       }
-    }
-    if (sellerId && listing.sellerId !== sellerId) {
-      return false;
-    }
-    return true;
-  });
+      if (game) {
+        const card = cards.find((item) => item.id === listing.cardId);
+        if (!card || card.game.toLowerCase() !== game.toLowerCase()) {
+          return false;
+        }
+      }
+      if (sellerId && listing.sellerId !== sellerId) {
+        return false;
+      }
+      if (typeof minPrice === 'number' && listing.price < minPrice) {
+        return false;
+      }
+      if (typeof maxPrice === 'number' && listing.price > maxPrice) {
+        return false;
+      }
+      return true;
+    })
+    .sort((a, b) => {
+      let comparison = 0;
+      if (normalizedSortBy === 'price') {
+        comparison = a.price - b.price;
+      } else {
+        comparison = new Date(a.updatedAt).getTime() - new Date(b.updatedAt).getTime();
+      }
+      return normalizedSortOrder === 'asc' ? comparison : -comparison;
+    });
 }
 
 function createListing({ sellerId, cardId, price, currency, condition, description, photos }) {

--- a/backend/src/services/valuation.js
+++ b/backend/src/services/valuation.js
@@ -32,6 +32,48 @@ function getValuation(cardId) {
   };
 }
 
+function getTrendingValuations({ limit = 5, window = 7 } = {}) {
+  const normalizedLimit = Number.isFinite(limit) && limit > 0 ? Math.floor(limit) : 5;
+  const normalizedWindow = Number.isFinite(window) && window > 0 ? Math.floor(window) : 7;
+
+  const entries = Object.entries(valuations)
+    .map(([cardId, record]) => {
+      const history = record.history || [];
+      if (history.length < 2) {
+        return null;
+      }
+      const latest = history[history.length - 1];
+      const baselineIndex = Math.max(history.length - normalizedWindow - 1, 0);
+      const baseline = history[baselineIndex];
+      if (!baseline || !baseline.average || baseline.average === 0) {
+        return null;
+      }
+
+      const changeValue = latest.average - baseline.average;
+      const changePercent = Number(((changeValue / baseline.average) * 100).toFixed(2));
+      const card = cards.find((item) => item.id === cardId) || null;
+
+      return {
+        cardId,
+        card,
+        average: latest.average,
+        changeValue: Number(changeValue.toFixed(2)),
+        changePercent,
+        window: normalizedWindow,
+        sparkline: history.slice(Math.max(history.length - normalizedWindow - 1, 0)).map((point) => ({
+          date: point.date,
+          average: point.average,
+        })),
+      };
+    })
+    .filter(Boolean)
+    .sort((a, b) => b.changePercent - a.changePercent)
+    .slice(0, normalizedLimit);
+
+  return entries;
+}
+
 module.exports = {
   getValuation,
+  getTrendingValuations,
 };

--- a/backend/tests/app.test.js
+++ b/backend/tests/app.test.js
@@ -64,6 +64,29 @@ test('card identification and valuation', async (t) => {
   assert.ok(Array.isArray(valuation.data.history));
 });
 
+test('card search tokenization and trending valuations', async (t) => {
+  const server = createApp().listen(0);
+  t.after(() => server.close());
+
+  const searchResponse = await request(server, '/api/cards/search?q=charizard%20base');
+  assert.strictEqual(searchResponse.status, 200);
+  assert.ok(searchResponse.data.results.length > 0);
+  assert.ok(
+    searchResponse.data.results.some((card) => card.id === 'card-charizard-holo'),
+    'Expected to find Charizard card in tokenized search results',
+  );
+
+  const trendingResponse = await request(server, '/api/cards/trending?limit=3&window=10');
+  assert.strictEqual(trendingResponse.status, 200);
+  assert.ok(Array.isArray(trendingResponse.data.results));
+  assert.ok(trendingResponse.data.results.length <= 3);
+  if (trendingResponse.data.results.length > 0) {
+    const [first] = trendingResponse.data.results;
+    assert.ok(typeof first.changePercent === 'number');
+    assert.ok(first.sparkline.length > 0);
+  }
+});
+
 test('marketplace listing creation requires auth', async (t) => {
   const server = createApp().listen(0);
   t.after(() => server.close());
@@ -88,6 +111,44 @@ test('marketplace listing creation requires auth', async (t) => {
 
   assert.strictEqual(response.status, 201);
   assert.strictEqual(response.data.listing.price, 38);
+});
+
+test('marketplace filters by price range and sorts', async (t) => {
+  const server = createApp().listen(0);
+  t.after(() => server.close());
+
+  const { data: login } = await request(server, '/api/auth/login', {
+    method: 'POST',
+    body: { email: 'ash@cardpulse.app', password: 'password123' },
+  });
+
+  const creationPayloads = [60, 160, 260].map((price) => ({
+    method: 'POST',
+    headers: { Authorization: `Bearer ${login.token}` },
+    body: {
+      cardId: 'card-pikachu-base',
+      price,
+      currency: 'USD',
+      condition: 'Mint',
+      description: `Test listing at $${price}`,
+    },
+  }));
+
+  for (const payload of creationPayloads) {
+    const createResponse = await request(server, '/api/marketplace/listings', payload);
+    assert.strictEqual(createResponse.status, 201);
+  }
+
+  const filtered = await request(
+    server,
+    '/api/marketplace/listings?minPrice=150&maxPrice=265&sortBy=price&sortOrder=asc',
+  );
+
+  assert.strictEqual(filtered.status, 200);
+  assert.ok(Array.isArray(filtered.data.listings));
+  assert.ok(filtered.data.listings.length >= 2);
+  const prices = filtered.data.listings.map((listing) => listing.price);
+  assert.deepStrictEqual(prices.slice(0, 2), [160, 260]);
 });
 
 test('forum posting and messaging flows', async (t) => {


### PR DESCRIPTION
## Summary
- improve card search scoring and add an endpoint for trending valuation snapshots
- expand marketplace listing filters with price range and sorting controls
- cover new capabilities with backend integration tests

## Testing
- npm test

------
https://chatgpt.com/codex/tasks/task_e_68f10f878124832ca4d9c214c65d7f19